### PR TITLE
WIP: Add support using & Fix default expressions via Overriding (Version 2)

### DIFF
--- a/ecs.yml
+++ b/ecs.yml
@@ -10,3 +10,4 @@ parameters:
   cache_directory: .ecs_cache
   exclude_files:
     - vendor/*
+    - src/Schema/Drivers/Traits/*

--- a/src/.meta.php
+++ b/src/.meta.php
@@ -17,4 +17,11 @@ namespace Illuminate\Database\Schema {
     class Blueprint
     {
     }
+
+    /**
+     * @method ColumnDefinition using($expression)
+     */
+    class ColumnDefinition
+    {
+    }
 }

--- a/src/PostgresConnection.php
+++ b/src/PostgresConnection.php
@@ -6,6 +6,7 @@ namespace Umbrellio\Postgres;
 
 use Illuminate\Database\PostgresConnection as BasePostgresConnection;
 use Umbrellio\Postgres\Schema\Builder;
+use Umbrellio\Postgres\Schema\Drivers\UmbrellioDoctrineDriver;
 use Umbrellio\Postgres\Schema\Grammars\PostgresGrammar;
 
 class PostgresConnection extends BasePostgresConnection
@@ -21,5 +22,10 @@ class PostgresConnection extends BasePostgresConnection
     protected function getDefaultSchemaGrammar()
     {
         return $this->withTablePrefix(new PostgresGrammar());
+    }
+
+    protected function getDoctrineDriver()
+    {
+        return new UmbrellioDoctrineDriver();
     }
 }

--- a/src/Schema/Drivers/Platforms/UmbrellioSQL100Platform.php
+++ b/src/Schema/Drivers/Platforms/UmbrellioSQL100Platform.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers\Platforms;
+
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Umbrellio\Postgres\Schema\Drivers\Traits\AlterTableSQLDeclarations;
+
+class UmbrellioSQL100Platform extends PostgreSQL100Platform
+{
+    use AlterTableSQLDeclarations;
+}

--- a/src/Schema/Drivers/Platforms/UmbrellioSQL91Platform.php
+++ b/src/Schema/Drivers/Platforms/UmbrellioSQL91Platform.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers\Platforms;
+
+use Doctrine\DBAL\Platforms\PostgreSQL91Platform;
+use Umbrellio\Postgres\Schema\Drivers\Traits\AlterTableSQLDeclarations;
+
+class UmbrellioSQL91Platform extends PostgreSQL91Platform
+{
+    use AlterTableSQLDeclarations;
+}

--- a/src/Schema/Drivers/Platforms/UmbrellioSQL92Platform.php
+++ b/src/Schema/Drivers/Platforms/UmbrellioSQL92Platform.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers\Platforms;
+
+use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
+use Umbrellio\Postgres\Schema\Drivers\Traits\AlterTableSQLDeclarations;
+
+class UmbrellioSQL92Platform extends PostgreSQL92Platform
+{
+    use AlterTableSQLDeclarations;
+}

--- a/src/Schema/Drivers/Platforms/UmbrellioSQL94Platform.php
+++ b/src/Schema/Drivers/Platforms/UmbrellioSQL94Platform.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers\Platforms;
+
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Umbrellio\Postgres\Schema\Drivers\Traits\AlterTableSQLDeclarations;
+
+class UmbrellioSQL94Platform extends PostgreSQL94Platform
+{
+    use AlterTableSQLDeclarations;
+}

--- a/src/Schema/Drivers/Traits/AlterTableSQLDeclarations.php
+++ b/src/Schema/Drivers/Traits/AlterTableSQLDeclarations.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers\Traits;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Identifier;
+use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\BigIntType;
+use Doctrine\DBAL\Types\BinaryType;
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\IntegerType;
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Query\Expression;
+
+/**
+ * @method bool onSchemaAlterTableAddColumn(Column $column, TableDiff $diff, &$columnSql)
+ * @method string getColumnDeclarationSQL($name, array $field)
+ * @method string|null getColumnComment(Column $column)
+ * @method getCommentOnColumnSQL($tableName, $columnName, $comment)
+ * @method bool onSchemaAlterTableRemoveColumn(Column $column, TableDiff $diff, &$columnSql)
+ * @method bool SchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql)
+ * @method string getDefaultValueDeclarationSQL($field)
+ * @method getIdentitySequenceName($tableName, $columnName)
+ * @method bool onSchemaAlterTableChangeColumn(ColumnDiff $columnDiff, TableDiff $diff, &$columnSql)
+ * @method string[] getPreAlterTableIndexForeignKeySQL(TableDiff $diff)
+ * @method string[] getPostAlterTableIndexForeignKeySQL(TableDiff $diff)
+ * @method bool onSchemaAlterTable(TableDiff $diff, &$sql)
+ * @method bool onSchemaAlterTableRenameColumn($oldColumnName, Column $column, TableDiff $diff, &$columnSql)
+ */
+trait AlterTableSQLDeclarations
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getAlterTableAddColumnSQL(string $table, string $column): string
+    {
+        return sprintf('ALTER TABLE %s ADD %s', $table, $column);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getAlterTableDropColumnSQL(string $table, string $column): string
+    {
+        return sprintf('ALTER TABLE %s DROP %s', $table, $column);
+    }
+
+    public function getAlterTableAlterTypeColumnSQL(
+        string $table,
+        string $column,
+        string $type,
+        array $columnDefinition
+    ): string {
+        $using = '';
+        if ($columnDefinition['using'] ?? false) {
+            $using = 'USING ' . $columnDefinition['using'];
+        }
+        return trim(sprintf('ALTER TABLE %s ALTER %s TYPE %s %s', $table, $column, $type, $using));
+    }
+
+    public function getAlterTableAlterDefaultSQL(string $table, string $columnName, Column $column): string
+    {
+        if ($column->getDefault() === null) {
+            return sprintf('ALTER TABLE %s ALTER %s DROP DEFAULT', $table, $columnName);
+        }
+
+        return sprintf(
+            'ALTER TABLE %s ALTER %s SET %s',
+            $table,
+            $columnName,
+            trim($this->fixDefaultValueDeclarationSQL($column))
+        );
+    }
+
+    public function fixDefaultValueDeclarationSQL(Column $column): string
+    {
+        if ($column->getDefault() instanceof Expression) {
+            return ' DEFAULT ' . $column->getDefault();
+        }
+        return $this->getDefaultValueDeclarationSQL($column->toArray());
+    }
+
+    public function getAlterTableRenameColumnSQL(string $table, string $oldColumn, string $newColumn): string
+    {
+        return sprintf('ALTER TABLE %s RENAME COLUMN %s TO %s', $table, $oldColumn, $newColumn);
+    }
+
+    public function getAlterTableAlterNotNullSQL(string $table, string $columnName, Column $column): string
+    {
+        return sprintf(
+            'ALTER TABLE %s ALTER %s %s NOT NULL',
+            $table,
+            $columnName,
+            $column->getNotnull() ? 'SET' : 'DROP'
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getAlterTableRenameToSQL(string $table, string $name): string
+    {
+        return sprintf('ALTER TABLE %s RENAME TO %s', $table, $name);
+    }
+
+    public function getSetSequenceValueSQL(string $table, string $column, string $sequence): string
+    {
+        return sprintf("SELECT setval('%s', (SELECT MAX(%s) FROM %s))", $sequence, $column, $table);
+    }
+
+    public function getCreateSimpleSequenceSQL(string $sequence): string
+    {
+        return sprintf('CREATE SEQUENCE %s', $sequence);
+    }
+
+    public function getAlterTableSQL(TableDiff $diff)
+    {
+        $sql = [];
+        $commentsSQL = [];
+        $columnSql = [];
+
+        foreach ($diff->addedColumns as $column) {
+            // @codeCoverageIgnoreStart
+            if ($this->onSchemaAlterTableAddColumn($column, $diff, $columnSql)) {
+                continue;
+            }
+
+            $sql[] = $this->getAlterTableAddColumnSQL(
+                $diff->getName($this)->getQuotedName($this),
+                $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray())
+            );
+
+            $comment = $this->getColumnComment($column);
+
+            if ($comment === null || $comment === '') {
+                continue;
+            }
+
+            $commentsSQL[] = $this->getCommentOnColumnSQL(
+                $diff->getName($this)->getQuotedName($this),
+                $column->getQuotedName($this),
+                $comment
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        foreach ($diff->removedColumns as $column) {
+            // @codeCoverageIgnoreStart
+            if ($this->onSchemaAlterTableRemoveColumn($column, $diff, $columnSql)) {
+                continue;
+            }
+
+            $sql[] = $this->getAlterTableDropColumnSQL(
+                $diff->getName($this)->getQuotedName($this),
+                $column->getQuotedName($this)
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        foreach ($diff->changedColumns as $columnDiff) {
+            if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
+                // @codeCoverageIgnoreStart
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            if ($this->isUnchangedBinaryColumn($columnDiff)) {
+                // @codeCoverageIgnoreStart
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
+            $column = $columnDiff->column;
+
+            if ($columnDiff->hasChanged('type')
+                || $columnDiff->hasChanged('precision')
+                || $columnDiff->hasChanged('scale')
+                || $columnDiff->hasChanged('fixed')
+            ) {
+                $type = $column->getType();
+
+                $columnDefinition = $column->toArray();
+                $columnDefinition['autoincrement'] = false;
+
+                $sql[] = $this->getAlterTableAlterTypeColumnSQL(
+                    $diff->getName($this)->getQuotedName($this),
+                    $oldColumnName,
+                    $type->getSQLDeclaration($columnDefinition, $this),
+                    $columnDefinition
+                );
+            }
+
+            if ($columnDiff->hasChanged('notnull')) {
+                $sql[] = $this->getAlterTableAlterNotNullSQL(
+                    $diff->getName($this)->getQuotedName($this),
+                    $oldColumnName,
+                    $column
+                );
+            }
+
+            if ($columnDiff->hasChanged('default')
+                || $this->typeChangeBreaksDefaultValue($columnDiff)
+            ) {
+                $sql[] = $this->getAlterTableAlterDefaultSQL(
+                    $diff->getName($this)->getQuotedName($this),
+                    $oldColumnName,
+                    $column
+                );
+            }
+
+            if ($columnDiff->hasChanged('autoincrement')) {
+                if ($column->getAutoincrement()) {
+                    $seqName = $this->getIdentitySequenceName($diff->name, $oldColumnName);
+
+                    $sql[] = $this->getCreateSimpleSequenceSQL($seqName);
+                    $sql[] = $this->getSetSequenceValueSQL(
+                        $diff->getName($this)->getQuotedName($this),
+                        $oldColumnName,
+                        $seqName
+                    );
+                    $sql[] = $this->getAlterTableAlterDefaultSQL(
+                        $diff->getName($this)->getQuotedName($this),
+                        $oldColumnName,
+                        $column->setDefault(new Expression("nextval('{$seqName}')"))
+                    );
+                } else {
+                    $sql[] = $this->getAlterTableAlterDefaultSQL(
+                        $diff->getName($this)->getQuotedName($this),
+                        $oldColumnName,
+                        $column->setDefault(null)
+                    );
+                }
+            }
+
+            $newComment = $this->getColumnComment($column);
+            $oldComment = $this->getOldColumnComment($columnDiff);
+
+            if ($columnDiff->hasChanged('comment')
+                || ($columnDiff->fromColumn !== null && $oldComment !== $newComment)
+            ) {
+                $commentsSQL[] = $this->getCommentOnColumnSQL(
+                    $diff->getName($this)->getQuotedName($this),
+                    $column->getQuotedName($this),
+                    $newComment
+                );
+            }
+
+            if (!$columnDiff->hasChanged('length')) {
+                continue;
+            }
+
+            $sql[] = $this->getAlterTableAlterTypeColumnSQL(
+                $diff->getName($this)->getQuotedName($this),
+                $oldColumnName,
+                $column->getType()->getSQLDeclaration($column->toArray(), $this),
+                $column->toArray()
+            );
+        }
+
+        foreach ($diff->renamedColumns as $oldColumnName => $column) {
+            if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
+                // @codeCoverageIgnoreStart
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            $oldColumnName = new Identifier($oldColumnName);
+
+            $sql[] = $this->getAlterTableRenameColumnSQL(
+                $diff->getName($this)->getQuotedName($this),
+                $oldColumnName->getQuotedName($this),
+                $column->getQuotedName($this)
+            );
+        }
+
+        $tableSql = [];
+
+        if (!$this->onSchemaAlterTable($diff, $tableSql)) {
+            $sql = array_merge($sql, $commentsSQL);
+
+            $newName = $diff->getNewName();
+
+            if ($newName !== false) {
+                // @codeCoverageIgnoreStart
+                $sql[] = $this->getAlterTableRenameToSQL(
+                    $diff->getName($this)->getQuotedName($this),
+                    $newName->getQuotedName($this)
+                );
+                // @codeCoverageIgnoreEnd
+            }
+
+            $sql = array_merge(
+                $this->getPreAlterTableIndexForeignKeySQL($diff),
+                $sql,
+                $this->getPostAlterTableIndexForeignKeySQL($diff)
+            );
+        }
+
+        return array_merge($sql, $tableSql, $columnSql);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function isUnchangedBinaryColumn(ColumnDiff $columnDiff): bool
+    {
+        $columnType = $columnDiff->column->getType();
+
+        if (!$columnType instanceof BinaryType && !$columnType instanceof BlobType) {
+            return false;
+        }
+
+        $fromColumn = $columnDiff->fromColumn instanceof Column ? $columnDiff->fromColumn : null;
+
+        if ($fromColumn) {
+            $fromColumnType = $fromColumn->getType();
+
+            if (!$fromColumnType instanceof BinaryType && !$fromColumnType instanceof BlobType) {
+                return false;
+            }
+
+            return count(array_diff($columnDiff->changedProperties, ['type', 'length', 'fixed'])) === 0;
+        }
+
+        if ($columnDiff->hasChanged('type')) {
+            return false;
+        }
+
+        return count(array_diff($columnDiff->changedProperties, ['length', 'fixed'])) === 0;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function typeChangeBreaksDefaultValue(ColumnDiff $columnDiff): bool
+    {
+        if (!$columnDiff->fromColumn) {
+            return $columnDiff->hasChanged('type');
+        }
+
+        $oldTypeIsNumeric = $this->isNumericType($columnDiff->fromColumn->getType());
+        $newTypeIsNumeric = $this->isNumericType($columnDiff->column->getType());
+
+        // default should not be changed when switching between numeric types and the default comes from a sequence
+        return $columnDiff->hasChanged('type')
+            && !($oldTypeIsNumeric && $newTypeIsNumeric && $columnDiff->column->getAutoincrement());
+    }
+
+    private function isNumericType(Type $type): bool
+    {
+        return $type instanceof IntegerType || $type instanceof BigIntType;
+    }
+
+    private function getOldColumnComment(ColumnDiff $columnDiff): ?string
+    {
+        return $columnDiff->fromColumn ? $this->getColumnComment($columnDiff->fromColumn) : null;
+    }
+}

--- a/src/Schema/Drivers/UmbrellioDoctrineDriver.php
+++ b/src/Schema/Drivers/UmbrellioDoctrineDriver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOPgSql\Driver;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL91Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Umbrellio\Postgres\Schema\Drivers\Platforms\UmbrellioSQL100Platform;
+use Umbrellio\Postgres\Schema\Drivers\Platforms\UmbrellioSQL91Platform;
+use Umbrellio\Postgres\Schema\Drivers\Platforms\UmbrellioSQL92Platform;
+use Umbrellio\Postgres\Schema\Drivers\Platforms\UmbrellioSQL94Platform;
+use Umbrellio\Postgres\Schema\UmbrellioSqlSchemaManager;
+
+/**
+ * @codeCoverageIgnore
+ */
+class UmbrellioDoctrineDriver extends Driver
+{
+    public function getDatabasePlatform()
+    {
+        return new UmbrellioSqlPlatform();
+    }
+
+    public function getSchemaManager(Connection $conn)
+    {
+        return new UmbrellioSqlSchemaManager($conn);
+    }
+
+    public function createDatabasePlatformForVersion($version)
+    {
+        $platform = parent::createDatabasePlatformForVersion($version);
+        switch (true) {
+            case $platform instanceof PostgreSQL100Platform:
+                return new UmbrellioSQL100Platform();
+            case $platform instanceof PostgreSQL94Platform:
+                return new UmbrellioSQL94Platform();
+            case $platform instanceof PostgreSQL92Platform:
+                return new UmbrellioSQL92Platform();
+            case $platform instanceof PostgreSQL91Platform:
+                return new UmbrellioSQL91Platform();
+            default:
+                return $this->getDatabasePlatform();
+        }
+    }
+}

--- a/src/Schema/Drivers/UmbrellioSqlPlatform.php
+++ b/src/Schema/Drivers/UmbrellioSqlPlatform.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema\Drivers;
+
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Umbrellio\Postgres\Schema\Drivers\Traits\AlterTableSQLDeclarations;
+
+class UmbrellioSqlPlatform extends PostgreSqlPlatform
+{
+    use AlterTableSQLDeclarations;
+}

--- a/src/Schema/UmbrellioSqlSchemaManager.php
+++ b/src/Schema/UmbrellioSqlSchemaManager.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Schema;
+
+use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+
+class UmbrellioSqlSchemaManager extends PostgreSqlSchemaManager
+{
+}

--- a/tests/Functional/ChangeTest.php
+++ b/tests/Functional/ChangeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umbrellio\Postgres\Tests\Functional;
+
+use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\Schema;
+use Umbrellio\Postgres\Schema\Blueprint;
+
+class ChangeTest extends FunctionalTestCase
+{
+    /** @test */
+    public function schemaChanges(): void
+    {
+        Schema::create('test_table', function (Blueprint $table) {
+            $table->integer('id')->default(1);
+            $table->string('name')->nullable()->default(new Expression('NULL'));
+            $table->binary('binaries');
+            $table->string('email')->unique();
+            $table->tinyInteger('phone')->unsigned();
+            $table->boolean('enabled')->default(0)->comment('Enabled');
+        });
+
+        $this->assertTrue(Schema::hasTable('test_table'));
+        $this->assertSame(
+            ['id', 'name', 'binaries', 'email', 'phone', 'enabled'],
+            Schema::getColumnListing('test_table')
+        );
+
+        Schema::table('test_table', function (Blueprint $table) {
+            $table->integer('id')->primary()->change();
+            $table->string('email')->nullable()->default(new Expression('NULL'))->change();
+            $table->string('binaries')->nullable()->change();
+            $table->string('test1');
+            $table->string('test2')->comment('test_comment');
+            $table->string('dump1')->nullable();
+            $table->dropColumn(['dump1']);
+        });
+
+        $this->assertSame(
+            ['id', 'name', 'binaries', 'email', 'phone', 'enabled', 'test1', 'test2'],
+            Schema::getColumnListing('test_table')
+        );
+
+        Schema::table('test_table', function (Blueprint $table) {
+            $table->integer('id')->autoIncrement()->change();
+            $table->string('email')->nullable()->default('player@example.om')->change();
+            $table->renameColumn('binaries', 'code');
+            $table->dropColumn(['phone', 'enabled']);
+            $table->binary('test1')->nullable()->using('test1::bytea')->change();
+            $table->string('test2')->comment('new_comment')->change();
+        });
+
+        $this->assertSame(['id', 'name', 'code', 'email', 'test1', 'test2'], Schema::getColumnListing('test_table'));
+
+        Schema::table('test_table', function (Blueprint $table) {
+            $table->dropPrimary(['id']);
+            $table->string('name', 100)->change();
+            $table->integer('id')->change();
+            $table->rename('some_table');
+        });
+
+        $this->assertTrue(Schema::hasTable('some_table'));
+
+        Schema::table('some_table', function (Blueprint $table) {
+            $table->drop();
+        });
+
+        $this->assertFalse(Schema::hasTable('some_table'));
+    }
+}


### PR DESCRIPTION
```php
use Illuminate\Database\Query\Expression;

...
Schema::table('some_table', function (Blueprint $table) {
    // code before was string 
    $table->integer('code')->using('code::integer')->change();

   ...
   $table->string('phone)->default(new Expression("''::character varying"));
})
```

Related: https://github.com/doctrine/dbal/pull/3628/files
