### PR TITLE
Moving register extensions to PostgresConnections

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ class SomeExtension extends AbstractExtension
 
 ```php
 use Illuminate\Support\ServiceProvider;
-use Umbrellio\Postgres\UmbrellioPostgresProvider;
+use Umbrellio\Postgres\PostgresConnection;
 
 class SomeServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        UmbrellioPostgresProvider::registerExtension(SomeExtension::class);
+        PostgresConnection::registerExtension(SomeExtension::class);
     }
 }
 ```

--- a/src/PostgresConnection.php
+++ b/src/PostgresConnection.php
@@ -6,12 +6,46 @@ namespace Umbrellio\Postgres;
 
 use Illuminate\Database\PostgresConnection as BasePostgresConnection;
 use Illuminate\Support\Traits\Macroable;
+use Umbrellio\Postgres\Extensions\AbstractExtension;
+use Umbrellio\Postgres\Extensions\Exceptions\ExtensionInvalidException;
 use Umbrellio\Postgres\Schema\Builder;
 use Umbrellio\Postgres\Schema\Grammars\PostgresGrammar;
 
 class PostgresConnection extends BasePostgresConnection
 {
     use Macroable;
+
+    private static $extensions = [];
+
+    /**
+     * @param AbstractExtension|string $extension
+     * @codeCoverageIgnore
+     */
+    final public static function registerExtension(string $extension): void
+    {
+        if (!is_subclass_of($extension, AbstractExtension::class)) {
+            throw new ExtensionInvalidException(sprintf(
+                'Class %s must be implemented from %s',
+                $extension,
+                AbstractExtension::class
+            ));
+        }
+        self::$extensions[$extension::getName()] = $extension;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    final private function registerExtensions(): void
+    {
+        collect(self::$extensions)->each(function ($extension, $key) {
+            /** @var AbstractExtension $extension */
+            $extension::register();
+            foreach ($extension::getTypes() as $type => $typeClass) {
+                $this->getSchemaBuilder()->registerCustomDoctrineType($typeClass, $type, $type);
+            }
+        });
+    }
 
     public function getSchemaBuilder()
     {
@@ -24,5 +58,11 @@ class PostgresConnection extends BasePostgresConnection
     protected function getDefaultSchemaGrammar()
     {
         return $this->withTablePrefix(new PostgresGrammar());
+    }
+    
+    public function useDefaultPostProcessor()
+    {
+        parent::useDefaultPostProcessor();
+        $this->registerExtensions();
     }
 }

--- a/src/PostgresConnection.php
+++ b/src/PostgresConnection.php
@@ -33,6 +33,25 @@ class PostgresConnection extends BasePostgresConnection
         self::$extensions[$extension::getName()] = $extension;
     }
 
+    public function getSchemaBuilder()
+    {
+        if ($this->schemaGrammar === null) {
+            $this->useDefaultSchemaGrammar();
+        }
+        return new Builder($this);
+    }
+
+    public function useDefaultPostProcessor()
+    {
+        parent::useDefaultPostProcessor();
+        $this->registerExtensions();
+    }
+
+    protected function getDefaultSchemaGrammar()
+    {
+        return $this->withTablePrefix(new PostgresGrammar());
+    }
+
     /**
      * @codeCoverageIgnore
      */
@@ -45,24 +64,5 @@ class PostgresConnection extends BasePostgresConnection
                 $this->getSchemaBuilder()->registerCustomDoctrineType($typeClass, $type, $type);
             }
         });
-    }
-
-    public function getSchemaBuilder()
-    {
-        if ($this->schemaGrammar === null) {
-            $this->useDefaultSchemaGrammar();
-        }
-        return new Builder($this);
-    }
-
-    protected function getDefaultSchemaGrammar()
-    {
-        return $this->withTablePrefix(new PostgresGrammar());
-    }
-    
-    public function useDefaultPostProcessor()
-    {
-        parent::useDefaultPostProcessor();
-        $this->registerExtensions();
     }
 }

--- a/src/UmbrellioPostgresProvider.php
+++ b/src/UmbrellioPostgresProvider.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Umbrellio\Postgres;
 
-use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\DatabaseServiceProvider;
-use Illuminate\Support\Facades\DB;
 use Umbrellio\Postgres\Connectors\ConnectionFactory;
-use Umbrellio\Postgres\Extensions\AbstractExtension;
-use Umbrellio\Postgres\Extensions\Exceptions\ExtensionInvalidException;
 
 class UmbrellioPostgresProvider extends DatabaseServiceProvider
 {

--- a/tests/Unit/Schema/Grammars/GrammarTest.php
+++ b/tests/Unit/Schema/Grammars/GrammarTest.php
@@ -17,7 +17,7 @@ class GrammarTest extends TestCase
     {
         $blueprint = new Blueprint('test');
         $blueprint->gin('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getConnectionMock(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('CREATE INDEX', $statements[0]);
         $this->assertStringContainsString('GIN("foo")', $statements[0]);
@@ -28,16 +28,13 @@ class GrammarTest extends TestCase
     {
         $blueprint = new Blueprint('test');
         $blueprint->gist('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getConnectionMock(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('CREATE INDEX', $statements[0]);
         $this->assertStringContainsString('GIST("foo")', $statements[0]);
     }
 
-    /**
-     * @return PostgresConnection
-     */
-    protected function getConnection()
+    protected function getConnectionMock()
     {
         return Mockery::mock(PostgresConnection::class);
     }


### PR DESCRIPTION
Registration of user extensions is removed from UmbrellioPostgresProvider in PostgresConnection.