### PR TITLE
Add numeric column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Schema::table('some_table', function (Blueprint $table) {
 });
 ```
 
+### Numeric column type
+Unlike standard laravel `decimal` type, this type can be with [variable precision](https://www.postgresql.org/docs/current/datatype-numeric.html) 
+```php
+Schema::table('some_table', function (Blueprint $table) {
+   $table->numeric('column_with_variable_precision');
+   $table->numeric('column_with_defined_precision', 8);
+   $table->numeric('column_with_defined_precision_and_scale', 8, 2);
+});
+```
+
 ## Custom Extensions
 
 1). Create a repository for your extension.

--- a/src/.meta.php
+++ b/src/.meta.php
@@ -15,7 +15,7 @@ namespace Illuminate\Database\Schema {
      * @method UniqueDefinition uniquePartial($columns, ?string $index = null, ?string $algorithm = null)
      * @method Fluent gin($columns, ?string $name = null)
      * @method Fluent gist($columns, ?string $name = null)
-     * @method Fluent numeric(string $column, ?int $precision = null, ?int $scale = null)
+     * @method ColumnDefinition numeric(string $column, ?int $precision = null, ?int $scale = null):
      */
     class Blueprint
     {

--- a/src/.meta.php
+++ b/src/.meta.php
@@ -15,6 +15,7 @@ namespace Illuminate\Database\Schema {
      * @method UniqueDefinition uniquePartial($columns, ?string $index = null, ?string $algorithm = null)
      * @method Fluent gin($columns, ?string $name = null)
      * @method Fluent gist($columns, ?string $name = null)
+     * @method Fluent numeric(string $column, ?int $precision = null, ?int $scale = null)
      */
     class Blueprint
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -89,10 +89,6 @@ class Blueprint extends BaseBlueprint
 
     /**
      * Almost like 'decimal' type, but can be with variable precision (by default)
-     * @param string $column
-     * @param int|null $precision
-     * @param int|null $scale
-     * @return ColumnDefinition
      */
     public function numeric(string $column, ?int $precision = null, ?int $scale = null): ColumnDefinition
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Umbrellio\Postgres\Schema;
 
 use Illuminate\Database\Schema\Blueprint as BaseBlueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Fluent;
 use Umbrellio\Postgres\Schema\Builders\UniquePartialBuilder;
@@ -91,9 +92,9 @@ class Blueprint extends BaseBlueprint
      * @param string $column
      * @param int|null $precision
      * @param int|null $scale
-     * @return \Illuminate\Database\Schema\ColumnDefinition
+     * @return ColumnDefinition
      */
-    public function numeric(string $column, ?int $precision = null, ?int $scale = null)
+    public function numeric(string $column, ?int $precision = null, ?int $scale = null): ColumnDefinition
     {
         return $this->addColumn('numeric', $column, compact('precision', 'scale'));
     }

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -86,6 +86,18 @@ class Blueprint extends BaseBlueprint
         return array_key_exists($index, $this->getSchemaManager()->listTableIndexes($this->getTable()));
     }
 
+    /**
+     * Almost like 'decimal' type, but can be with variable precision (by default)
+     * @param string $column
+     * @param int|null $precision
+     * @param int|null $scale
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function numeric(string $column, ?int $precision = null, ?int $scale = null)
+    {
+        return $this->addColumn('numeric', $column, compact('precision', 'scale'));
+    }
+
     protected function addFluentIndexes(): void
     {
         foreach ($this->columns as $column) {

--- a/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/Schema/Grammars/PostgresGrammar.php
@@ -70,4 +70,16 @@ class PostgresGrammar extends BasePostgresGrammar
             $this->columnize($command->columns)
         );
     }
+
+    protected function typeNumeric(Fluent $column): string
+    {
+        $type = 'numeric';
+        if ($column->precision && $column->scale) {
+            return "${type}({$column->precision}, {$column->scale})";
+        }
+        if ($column->precision) {
+            return "${type}({$column->precision})";
+        }
+        return $type;
+    }
 }

--- a/tests/Unit/Schema/BlueprintTest.php
+++ b/tests/Unit/Schema/BlueprintTest.php
@@ -66,6 +66,27 @@ class BlueprintTest extends TestCase
             . "for values from ('{$today->toDateTimeString()}') to ('{$tomorrow->toDateTimeString()}')");
     }
 
+    /** @test */
+    public function addingNumericColumnWithVariablePrecicion()
+    {
+        $this->blueprint->numeric('foo');
+        $this->assertSameSql('alter table "test_table" add column "foo" numeric not null');
+    }
+
+    /** @test */
+    public function addingNumericColumnWithDefinedPrecicion()
+    {
+        $this->blueprint->numeric('foo', 8);
+        $this->assertSameSql('alter table "test_table" add column "foo" numeric(8) not null');
+    }
+
+    /** @test */
+    public function addingNumericColumnWithDefinedPrecicionAndScope()
+    {
+        $this->blueprint->numeric('foo', 8, 2);
+        $this->assertSameSql('alter table "test_table" add column "foo" numeric(8, 2) not null');
+    }
+
     private function assertSameSql(string $sql): void
     {
         $this->assertSame([$sql], $this->runToSql());


### PR DESCRIPTION
This PR adds numeric column type to schema builder. that. unlike 'decimal' type can be with variable precision