### PR TITLE
Added support deleting UNIQUE partial indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,6 @@ Schema::create('table', function (Blueprint $table) {
 define a partial (ie conditional) UNIQUE constraint. If you try to delete such a Partial Unique
 Index you will get an error.
 
-But in this case, the clear preferred method is a unique constraint, with which you still 
-get an automatic unique index. If you are creating a table from scratch, this is absolutely
-the way to go. If you are adding a uniqueness constraint to an existing table, you may still
-find yourself erring on the side of a unique index, if only because an index can be created
-concurrently while a constraint cannot. Should you choose a concurrent index in this case,
-you can add a unique constraint that depends on that index, effectively doing manually what
-PostgreSQL would have done automatically on a new table:
 ```SQL
 CREATE UNIQUE INDEX CONCURRENTLY examples_new_col_idx ON examples (new_col);
 ALTER TABLE examples

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Schema::create('table', function (Blueprint $table) {
 Schema::table('table', function (Blueprint $table) {
     $table
         ->string('number')
-        ->using("('[' || number || ']')::character varyiing")
+        ->using("('[' || number || ']')::character varying")
         ->change();
 });
 ```
@@ -61,7 +61,7 @@ Schema::dropView('active_users')
 // Schema methods:
 Schema::create('users', function (Blueprint $table) {
     $table
-        ->createView('active_users', , "SELECT * FROM users WHERE active = 1")
+        ->createView('active_users', "SELECT * FROM users WHERE active = 1")
         ->materialize();
 });
 ```
@@ -76,6 +76,34 @@ Schema::create('table', function (Blueprint $table) {
     $table->uniquePartial('code')->whereNull('deleted_at');
 });
 ```
+
+If you are want delete partial unique index, use this method:
+```php
+Schema::create('table', function (Blueprint $table) {
+    $table->dropUniquePartial(['code']);
+});
+```
+
+`$table->dropUnique()` doesn't work for Partial Unique Indexes, because PostgreSQL doesn't
+define a partial (ie conditional) UNIQUE constraint. If you try to delete such a Partial Unique
+Index you will get an error.
+
+But in this case, the clear preferred method is a unique constraint, with which you still 
+get an automatic unique index. If you are creating a table from scratch, this is absolutely
+the way to go. If you are adding a uniqueness constraint to an existing table, you may still
+find yourself erring on the side of a unique index, if only because an index can be created
+concurrently while a constraint cannot. Should you choose a concurrent index in this case,
+you can add a unique constraint that depends on that index, effectively doing manually what
+PostgreSQL would have done automatically on a new table:
+```SQL
+CREATE UNIQUE INDEX CONCURRENTLY examples_new_col_idx ON examples (new_col);
+ALTER TABLE examples
+    ADD CONSTRAINT examples_unique_constraint USING INDEX examples_new_col_idx;
+```
+
+When you create a unique index without conditions, PostgresSQL will create Unique Constraint
+automatically for you, and when you try to delete such an index, Constraint will be deleted 
+first, then Unique Index. 
 
 ### Partitions
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Schema::create('table', function (Blueprint $table) {
 });
 ```
 
-If you are want delete partial unique index, use this method:
+If you want to delete partial unique index, use this method:
 ```php
 Schema::create('table', function (Blueprint $table) {
     $table->dropUniquePartial(['code']);

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -59,6 +59,11 @@ class Blueprint extends BaseBlueprint
         );
     }
 
+    public function dropUniquePartial($index): Fluent
+    {
+        return $this->dropIndexCommand('dropIndex', 'unique', $index);
+    }
+
     public function hasIndex($index, bool $unique = false): bool
     {
         if (is_array($index)) {

--- a/tests/Functional/Helpers/ColumnAssertions.php
+++ b/tests/Functional/Helpers/ColumnAssertions.php
@@ -39,6 +39,7 @@ trait ColumnAssertions
     {
         $this->assertSame($expected, Schema::getColumnType($table, $column));
     }
+
     private function getCommentListing(string $table, string $column)
     {
         $definition = DB::selectOne(

--- a/tests/Functional/Helpers/IndexAssertions.php
+++ b/tests/Functional/Helpers/IndexAssertions.php
@@ -17,6 +17,11 @@ trait IndexAssertions
         $this->assertNotNull($this->getIndexListing($index));
     }
 
+    protected function notSeeIndex(string $index): void
+    {
+        $this->assertNull($this->getIndexListing($index));
+    }
+
     protected function assertSameIndex(string $index, string $expectedDef): void
     {
         $definition = $this->getIndexListing($index);
@@ -32,10 +37,25 @@ trait IndexAssertions
         $this->seeIndex($index);
         $this->assertRegExp($expectedDef, $definition);
     }
+
     private function getIndexListing($index): ?string
     {
-        $definition = DB::selectOne('SELECT indexdef FROM pg_indexes WHERE indexname = ?', [$index]);
+        $definition = DB::selectOne('SELECT * FROM pg_indexes WHERE indexname = ?', [$index]);
 
         return $definition ? $definition->indexdef : null;
+    }
+
+    private function seeConstraintOnTable(string $table, string $type, string $index): bool
+    {
+        $definition = DB::selectOne(
+             '
+            SELECT constraint_name, constraint_type
+            FROM information_schema.table_constraints
+            WHERE table_name = ? AND constraint_type = ? AND constraint_name = ?
+            ',
+             [$table, $type, $index]
+        );
+
+        return $definition ? true : false;
     }
 }

--- a/tests/Functional/Schema/CreateIndexTest.php
+++ b/tests/Functional/Schema/CreateIndexTest.php
@@ -62,7 +62,7 @@ class CreateIndexTest extends FunctionalTestCase
         $this->assertRegExpIndex('test_table_name_unique', '/' . $this->getDummyIndex() . $expected . '/');
 
         Schema::table('test_table', function (Blueprint $table) {
-            if (!$this->seeConstraintOnTable($table->getTable(), 'UNIQUE', 'test_table_name_unique')) {
+            if (!$this->existConstraintOnTable($table->getTable(), 'test_table_name_unique')) {
                 $table->dropUniquePartial(['name']);
             } else {
                 $table->dropUnique(['name']);

--- a/tests/Functional/Schema/CreateIndexTest.php
+++ b/tests/Functional/Schema/CreateIndexTest.php
@@ -10,11 +10,12 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Schema;
 use Umbrellio\Postgres\Schema\Blueprint;
 use Umbrellio\Postgres\Tests\Functional\Helpers\IndexAssertions;
+use Umbrellio\Postgres\Tests\Functional\Helpers\TableAssertions;
 use Umbrellio\Postgres\Tests\FunctionalTestCase;
 
 class CreateIndexTest extends FunctionalTestCase
 {
-    use DatabaseTransactions, IndexAssertions;
+    use DatabaseTransactions, IndexAssertions, TableAssertions;
 
     /** @test */
     public function createIndexIfNotExists(): void
@@ -28,7 +29,7 @@ class CreateIndexTest extends FunctionalTestCase
             }
         });
 
-        $this->assertTrue(Schema::hasTable('test_table'));
+        $this->seeTable('test_table');
 
         Schema::table('test_table', function (Blueprint $table) {
             if (!$table->hasIndex(['name'], true)) {
@@ -43,7 +44,7 @@ class CreateIndexTest extends FunctionalTestCase
      * @test
      * @dataProvider provideIndexes
      */
-    public function createPartialUniqueWithNull(string $expected, Closure $callback): void
+    public function createPartialUnique(string $expected, Closure $callback): void
     {
         Schema::create('test_table', function (Blueprint $table) use ($callback) {
             $table->increments('id');
@@ -57,8 +58,18 @@ class CreateIndexTest extends FunctionalTestCase
             $callback($table);
         });
 
-        $this->assertTrue(Schema::hasTable('test_table'));
+        $this->seeTable('test_table');
         $this->assertRegExpIndex('test_table_name_unique', '/' . $this->getDummyIndex() . $expected . '/');
+
+        Schema::table('test_table', function (Blueprint $table) {
+            if (!$this->seeConstraintOnTable($table->getTable(), 'UNIQUE', 'test_table_name_unique')) {
+                $table->dropUniquePartial(['name']);
+            } else {
+                $table->dropUnique(['name']);
+            }
+        });
+
+        $this->notSeeIndex('test_table_name_unique');
     }
 
     /** @test */
@@ -68,7 +79,7 @@ class CreateIndexTest extends FunctionalTestCase
             $table->string('name')->index('specify_index_name');
         });
 
-        $this->assertTrue(Schema::hasTable('test_table'));
+        $this->seeTable('test_table');
 
         $this->assertRegExpIndex(
             'specify_index_name',


### PR DESCRIPTION
Added support for deleting unique indexes with WHERE conditions.

By default, if the created unique index contains no conditions, PostgresSQL automatically creates a Constraint for it, for example:

```SQL
CREATE UNIQUE INDEX CONCURRENTLY examples_new_col_idx ON examples (new_col);
ALTER TABLE examples
    ADD CONSTRAINT examples_unique_constraint USING INDEX examples_new_col_idx;
```

If the unique index contains WHERE conditions, then such a Constraint will not be created, because PostgreSQL doesn't
define a partial (ie conditional) UNIQUE constraint.

When trying to delete such a partial unique index, we get the error "Unique Constraint not found", so the standard command to remove `$table->dropUnique()` does not fit, the command `$table->dropIndex()` is suitable, but if pass the array there, then the index name will be generated as for a regular index with the suffix `_index`, instead of` _unique`, which we need.

And manually generating the index name is wrong.

This Merge Request solves these problems.