### PR TITLE
Refactor mixin components from extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ class SomeExtension extends AbstractExtension
     public static function getMixins(): array
     {
         return [
-            Blueprint::class => SomeBlueprint::class,
-            PostgresConnection::class => SomeConnection::class,
-            PostgresGrammar::class => SomeSchemaGrammar::class,
+            SomeBlueprint::class => Blueprint::class,
+            SomeConnection::class => PostgresConnection::class,
+            SomeSchemaGrammar::class => PostgresGrammar::class,
             ...
         ];
     }

--- a/src/Extensions/AbstractExtension.php
+++ b/src/Extensions/AbstractExtension.php
@@ -24,7 +24,7 @@ abstract class AbstractExtension extends AbstractComponent
 
     final public static function register(): void
     {
-        collect(static::getMixins())->each(static function ($mixin, $extension) {
+        collect(static::getMixins())->each(static function ($extension, $mixin) {
             if (!is_subclass_of($mixin, AbstractComponent::class)) {
                 throw new MixinInvalidException(sprintf(
                     'Mixed class %s is not descendant of %s.',

--- a/tests/Unit/Extensions/AbstractExtensionTest.php
+++ b/tests/Unit/Extensions/AbstractExtensionTest.php
@@ -18,20 +18,7 @@ class AbstractExtensionTest extends TestCase
     /** @test */
     public function registerInvalidExtension(): void
     {
-        $abstractExtension = new class() extends AbstractExtension {
-            public static function getName(): string
-            {
-                return 'extension';
-            }
-
-            public static function getMixins(): array
-            {
-                return [
-                    Blueprint::class => new class() extends Model {
-                    },
-                ];
-            }
-        };
+        $abstractExtension = new ExtensionStub();
 
         $this->expectException(MixinInvalidException::class);
 
@@ -42,24 +29,49 @@ class AbstractExtensionTest extends TestCase
     /** @test */
     public function registerWithInvalidMixin(): void
     {
-        $abstractExtension = new class() extends AbstractExtension {
-            public static function getName(): string
-            {
-                return 'extension';
-            }
-
-            public static function getMixins(): array
-            {
-                return [
-                    ServiceProvider::class => new class() extends AbstractComponent {
-                    },
-                ];
-            }
-        };
+        $abstractExtension = new InvalidExtensionStub();
 
         $this->expectException(MacroableMissedException::class);
 
         /** @var AbstractExtension $abstractExtension */
         $abstractExtension::register();
     }
+}
+
+class InvalidExtensionStub extends AbstractExtension
+{
+    public static function getName(): string
+    {
+        return 'extension';
+    }
+
+    public static function getMixins(): array
+    {
+        return [
+            ComponentStub::class => ServiceProvider::class,
+        ];
+    }
+}
+
+class ComponentStub extends AbstractComponent
+{
+}
+
+class ExtensionStub extends AbstractExtension
+{
+    public static function getName(): string
+    {
+        return 'extension';
+    }
+
+    public static function getMixins(): array
+    {
+        return [
+            InvalidComponentStub::class => Blueprint::class,
+        ];
+    }
+}
+
+class InvalidComponentStub extends Model
+{
 }


### PR DESCRIPTION
We changing strategy to mixing components, because, if you have more components in you extension, which's must are mixing with one component, you don't doing this.

Example,
```php
use App\Extensions\Eloquent\Components\CollectionFirst;
use App\Extensions\Eloquent\Components\CollectionSecond;
use Illuminate\Database\Eloquent\Collection;
use Umbrellio\Postgres\Extensions\AbstractExtension;

class EloquentExtension extends AbstractExtension
{
    private const NAME = 'eloquentExtension';

    public static function getMixins(): array
    {
        return [
            Collection::class => CollectionFirst::class,
            Collection::class => CollectionSecond::class, // duplicate index
        ];
    }

    public static function getName(): string
    {
        return static::NAME;
    }
}
```

or 

```php
    ...

    public static function getMixins(): array
    {
        return [
            CollectionFirst::class => Collection::class,
            CollectionSecond::class => Collection::class, // correct index
        ];
    }

    ...
}
```