### PR TITLE
Update doctrine/dbal version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   },
   "require": {
     "php": "^7.2|^7.3|^7.4|^8.0",
-    "doctrine/dbal": "2.9.*|^3.0",
+    "doctrine/dbal": "^2.9|^3.0",
     "laravel/framework": "^5.8|^6.0|^7.0|^8.0"
   },
   "require-dev": {


### PR DESCRIPTION
update doctrine/dbal version constraint to allow use 2.x version higher than ^2.9