### PR TITLE
feat: Add Laravel 10 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,30 @@ jobs:
             coverage: false
             experimental: false
             exclude_group: WithoutSchema,forPHP7
+          - operating_system: 'ubuntu-latest'
+            php_versions: '8.1'
+            postgres: '10'
+            experimental: false
+            coverage: false
+            exclude_group: WithoutSchema,forPHP7
+          - operating_system: 'ubuntu-latest'
+            php_versions: '8.1'
+            postgres: '11'
+            experimental: false
+            coverage: false
+            exclude_group: WithoutSchema,forPHP7
+          - operating_system: 'ubuntu-latest'
+            php_versions: '8.1'
+            postgres: '12'
+            experimental: false
+            coverage: true
+            exclude_group: WithoutSchema,forPHP7
+          - operating_system: 'ubuntu-latest'
+            php_versions: '8.1'
+            postgres: '13'
+            coverage: false
+            experimental: false
+            exclude_group: WithoutSchema,forPHP7
     runs-on: '${{ matrix.operating_system }}'
     services:
       postgres:

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     "umbrellio/code-style-php": "^1.0",
     "orchestra/testbench": "^3.5|^6.0|^4.0|^7.0|^8.0",
     "php-coveralls/php-coveralls": "^2.1",
-    "codeception/codeception": "^3.0|^4.0|^5.0"
+    "codeception/codeception": "^3.0|^4.0|^5.0",
+    "phpunit/phpunit": "^9.6"
   },
   "scripts": {
     "lint": [

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
     "ext-pdo": "*",
     "php": "^7.2|^7.3|^7.4|^8.0",
     "doctrine/dbal": "^2.9|^3.0",
-    "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^9.0"
+    "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0"
   },
   "require-dev": {
     "umbrellio/code-style-php": "^1.0",
-    "orchestra/testbench": "^3.5|^6.0|^4.0|^7.0",
+    "orchestra/testbench": "^3.5|^6.0|^4.0|^7.0|^8.0",
     "php-coveralls/php-coveralls": "^2.1",
-    "codeception/codeception": "^3.0|^4.0|^5.0.0-RC7"
+    "codeception/codeception": "^3.0|^4.0|^5.0"
   },
   "scripts": {
     "lint": [

--- a/src/Schema/Subscribers/SchemaAlterTableChangeColumnSubscriber.php
+++ b/src/Schema/Subscribers/SchemaAlterTableChangeColumnSubscriber.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\IntegerType;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection;
+use Umbrellio\Postgres\Schema\Grammars\PostgresGrammar;
 
 final class SchemaAlterTableChangeColumnSubscriber implements EventSubscriber
 {
@@ -197,8 +198,9 @@ final class SchemaAlterTableChangeColumnSubscriber implements EventSubscriber
 
     public function getDefaultValueDeclarationSQL(AbstractPlatform $platform, Column $column): string
     {
-        if ($column->getDefault() instanceof Expression) {
-            return ' DEFAULT ' . $column->getDefault();
+        $defaultValue = $column->getDefault();
+        if ($defaultValue instanceof Expression) {
+            return ' DEFAULT ' . $defaultValue->getValue(new PostgresGrammar());
         }
 
         return $platform->getDefaultValueDeclarationSQL($column->toArray());


### PR DESCRIPTION
Closes #76 

This pull request adds Laravel 10 support.

Since Laravel 10 now requires PHP 8.1, I added runs on PHP 8.1 into the CI workflow.
Also, PHP 8.1 is supported by PHPUnit 10; It will be automatically resolved and the CI workflow is not ready for PHPUnit 10. So I temporarily disabled resolving PHPUnit 10 and fixed to 9.6.