### PR TITLE
Fix compatibility latest version of Laravel with laravel/framework#49264

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -36,7 +36,7 @@ class Builder extends BasePostgresBuilder
         ])) > 0;
     }
 
-    public function getForeignKeys(string $tableName): array
+    public function getForeignKeys($tableName): array
     {
         return $this->connection->selectFromWriteConnection($this->grammar->compileForeignKeysListing($tableName));
     }


### PR DESCRIPTION
This Pull Request is a follow up of #82 by @mpyw.

After the previous Pull Request was created, laravel/framework#49264 provided a new method with the same name as our library:

https://github.com/laravel/framework/pull/49264/files#diff-1a147b8174f4809f7471525e9d676e831176efdbeb69af8af6e95c1a72aef962R366-R373

Fix it using the same idea as last time.

NOTE:

* According to laravel/framework#48864, the series of tasks on the framework side seems to have been completed, so the same fix will no longer be necessary in the future.
* IMO: Currently, our library does not work with the latest version of Laravel, so we *SHOULD* apply this Pull Request. However, I think that we *MAY NOT* override the framework's behavior, so if compatibility is confirmed, we *MAY* adopt the framework's method and remove our code.